### PR TITLE
Add equals and hashCode to Dependency

### DIFF
--- a/small/src/main/scala/com/geirsson/coursiersmall/Dependency.scala
+++ b/small/src/main/scala/com/geirsson/coursiersmall/Dependency.scala
@@ -1,4 +1,5 @@
 package com.geirsson.coursiersmall
+import scala.runtime.Statics
 
 final class Dependency(
     val organization: String,
@@ -6,7 +7,24 @@ final class Dependency(
     val version: String
 ) {
 
-  def asGradleString: String = s"$organization:$name:$version"
+  override def hashCode(): Int = {
+    var acc: Int = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(organization))
+    acc = Statics.mix(acc, Statics.anyHash(name))
+    acc = Statics.mix(acc, Statics.anyHash(version))
+    Statics.finalizeHash(acc, 4)
+  }
+
+  override def equals(obj: scala.Any): Boolean =
+    this.eq(obj.asInstanceOf[Object]) || (obj match {
+      case d: Dependency =>
+        organization == d.organization &&
+          name == d.name &&
+          version == d.version
+      case _ => false
+    })
+
+  def asCoursierString: String = s"$organization:$name:$version"
 
   override def toString: String = {
     s"""Dependency("$organization", "$name", "$version")"""

--- a/small/src/main/scala/com/geirsson/coursiersmall/ResolutionException.scala
+++ b/small/src/main/scala/com/geirsson/coursiersmall/ResolutionException.scala
@@ -10,7 +10,7 @@ final class ResolutionException(
       .append(settings.toString)
       .append("\n")
     errors.foreach { error =>
-      val dep = error.dependency.asGradleString
+      val dep = error.dependency.asCoursierString
       sb.append("Dependency ")
         .append("'")
         .append(dep)

--- a/small/src/test/scala/tests/DependencySuite.scala
+++ b/small/src/test/scala/tests/DependencySuite.scala
@@ -1,0 +1,16 @@
+package tests
+
+import utest._
+import com.geirsson.coursiersmall._
+
+object DependencySuite extends TestSuite {
+  val a = new Dependency("a", "a", "a")
+  val b = new Dependency("b", "b", "b")
+  val tests = Tests {
+    * - assert(a != new Dependency("a", "a", "b"))
+    * - assert(a != new Dependency("a", "b", "a"))
+    * - assert(a != new Dependency("b", "a", "a"))
+    * - assert(Set(a, a).toList == List(a))
+    * - assert(Set(a, b).toList == List(a, b))
+  }
+}


### PR DESCRIPTION
It's helpful to be able to use Dependency as keys in maps and sets.