### PR TITLE
Use java.io.Writer instead of java.io.PrintStream

### DIFF
--- a/small/src/main/scala/com/geirsson/coursiersmall/CoursierSmall.scala
+++ b/small/src/main/scala/com/geirsson/coursiersmall/CoursierSmall.scala
@@ -4,7 +4,6 @@ import java.nio.file.Path
 import coursier._
 import coursier.util.Gather
 import coursier.util.Task
-import java.io.OutputStreamWriter
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object CoursierSmall {
@@ -27,8 +26,7 @@ object CoursierSmall {
       case Repository.Ivy2Local => Cache.ivy2Local
       case maven: Repository.Maven => MavenRepository(maven.root)
     }
-    val term =
-      new TermDisplay(new OutputStreamWriter(settings.out), fallbackMode = true)
+    val term = new TermDisplay(settings.writer, fallbackMode = true)
     term.init()
     val fetch = Fetch.from(repositories, Cache.fetch[Task](logger = Some(term)))
     val resolution = res.process.run(fetch).unsafeRun()

--- a/small/src/main/scala/com/geirsson/coursiersmall/Settings.scala
+++ b/small/src/main/scala/com/geirsson/coursiersmall/Settings.scala
@@ -1,6 +1,7 @@
 package com.geirsson.coursiersmall
 
-import java.io.PrintStream
+import java.io.OutputStreamWriter
+import java.io.Writer
 
 /**
   * Configuration for a resolution.
@@ -8,13 +9,13 @@ import java.io.PrintStream
   * @param dependencies the root module dependencies to resolve.
   * @param repositories the external repositories to use for resolution,
   *                     defaults to Maven Central and ivy2local.
-  * @param out Where to print out progress and diagnostics during resolution and
-  *            downloading of artifacts.
+  * @param writer Where to print out progress and diagnostics during resolution and
+  *               downloading of artifacts.
   */
 final class Settings private (
     val dependencies: List[Dependency],
     val repositories: List[Repository],
-    val out: PrintStream
+    val writer: Writer
 ) {
 
   override def toString: String = {
@@ -31,7 +32,7 @@ final class Settings private (
         Repository.MavenCentral,
         Repository.Ivy2Local
       ),
-      out = System.out
+      writer = new OutputStreamWriter(System.out)
     )
   }
 
@@ -43,19 +44,19 @@ final class Settings private (
     copy(repositories = repositories)
   }
 
-  def withOut(out: PrintStream): Settings = {
-    copy(out = out)
+  def withWriter(writer: Writer): Settings = {
+    copy(writer = writer)
   }
 
   private[this] def copy(
       dependencies: List[Dependency] = this.dependencies,
       repositories: List[Repository] = this.repositories,
-      out: PrintStream = this.out
+      writer: Writer = this.writer
   ): Settings = {
     new Settings(
       dependencies = dependencies,
       repositories = repositories,
-      out = out
+      writer = writer
     )
   }
 }


### PR DESCRIPTION
This matches closer with the coursier API and makes it possible to
override `def write(String): Unit`, which is the method called
when printing diagnostics. It might be desirable to override `write`
to silence noisy diagnostics like "Downloading $URL.pom" that are
triggered on every invocation to coursier.